### PR TITLE
Fix seller relation in Product model

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -26,8 +26,12 @@ class Product extends Model
     }
 
     public function seller()
-    {  
-        return $this->belongsTo(SellerProfiles::class);
+    {
+        // The `seller_id` column on the products table references the users
+        // table. A seller profile record is linked to a user via `user_id`,
+        // so we need to specify that owner key explicitly when defining the
+        // relationship.
+        return $this->belongsTo(SellerProfiles::class, 'seller_id', 'user_id');
     }
 
     public function reviews()


### PR DESCRIPTION
## Summary
- correct the `seller()` relationship in the Product model so it joins seller profiles using `user_id`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d80410c00833084892adec9177c8d